### PR TITLE
Make Vagrant use Ubuntu 14.04 Trusty box

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Afterwards, visit http://reddit.local and enjoy your fresh new local reddit inst
 * Install your preferred vmware provider(VirtualBox, libvirt, and VMWare are supported)
   * VirtualBox - works out of the box, install VirtualBox on your host machine.
   * libvirt - `vagrant plugin install vagrant-libvirt` (you'll also need libvirt-dev on your host).
-    You will also need to use vagrant-mutate to convert the ubuntu/precise64 image to libvirt.
-    `vagrant box add ubuntu/precise64 && vagrant mutate ubuntu/precise64 libvirt`
+    You will also need to use vagrant-mutate to convert the ubuntu/trusty64 image to libvirt.
+    `vagrant box add ubuntu/trusty64 && vagrant mutate ubuntu/trusty64 libvirt`
   * VMWare - `vagrant plugin install vagrant-vmware-fusion` (you'll also need vmware-fusion)
   * NOTE - You will also need to choose the appropriate box for a particular provider in your
     vagrant_config.yml. VirtualBox is default

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ end
 # Minimum memory requirement is 2gb. Doubling to 4gb for safety.
 user_config = {
   private_ip: "192.168.150.2",
-  box: "ubuntu/precise64",
+  box: "ubuntu/trusty64",
   box_url: nil,
   forward_port: 8001,
   memory: 4096,

--- a/vagrant_config.yml.devexample
+++ b/vagrant_config.yml.devexample
@@ -1,8 +1,8 @@
 # Specify which vagrant box to use.
 # VBox/libvirt
-:box: "ubuntu/precise64"
+:box: "ubuntu/trusty64"
 #VMWare
-#:box: "spantree/ubuntu-precise-64"
+#:box: "lattice/ubuntu-trusty-64"
 
 # Assign a private IP to your box.
 :private_ip: "192.168.150.2"

--- a/vagrant_config.yml.example
+++ b/vagrant_config.yml.example
@@ -1,8 +1,8 @@
 # Specify which vagrant box to use.
 # VBox/libvirt
-:box: "ubuntu/precise64"
+:box: "ubuntu/trusty64"
 #VMWare
-#:box: "spantree/ubuntu-precise-64"
+#:box: "lattice/ubuntu-trusty-64"
 
 # Assign a private IP to your box.
 :private_ip: "192.168.150.2"


### PR DESCRIPTION
As of Aug 14, the codebase of Reddit is built for Ubuntu 14.04 LTS, not for Ubuntu 12.04. The current version of Vagrant box isn't successfully built because of the OS version inconsistency between the Reddit code and the Vagrant scripts. Thus, I modified the vagrant scripts to make Vagrant use Ubuntu 14.04 LTS Trusty 64-bit box instead of Ubuntu 12.04 box.